### PR TITLE
Update rails and ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine
+FROM ruby:2.7.7-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7.1-alpine
 
 WORKDIR /app
 
-ENV RAILS_VERSION=6.0.3.2
+ENV RAILS_VERSION=6.0.6.1
 ENV EDITOR=vim
 
 RUN apk update && apk add --update \


### PR DESCRIPTION
Update Rails and Ruby to the latest minor version so that Docker images can be built.

Fix mimemagic install error
```
$ docker buildx build -t medpeer/rails_cred:latest --load .
:
:
ERROR:  Error installing rails:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/mimemagic-0.3.10/ext/mimemagic
/usr/local/bin/ruby -I/usr/local/lib/ruby/2.7.0/rubygems -rrubygems /usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/exe/rake RUBYARCHDIR\=/usr/local/bundle/extensions/aarch64-linux-musl/2.7.0/mimemagic-0.3.10 RUBYLIBDIR\=/usr/local/bundle/extensions/aarch64-linux-musl/2.7.0/mimemagic-0.3.10
rake aborted!
Could not find MIME type database in the following locations: ["/usr/local/share/mime/packages/freedesktop.org.xml", "/opt/homebrew/share/mime/packages/freedesktop.org.xml", "/opt/local/share/mime/packages/freedesktop.org.xml", "/usr/share/mime/packages/freedesktop.org.xml"]
```